### PR TITLE
Enhancement to mysql configs

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -1,8 +1,6 @@
 mac=false
-mysql_user=root
-mysql_password=
-mysql_database=jest
-mysql_soft_delete=false
-mysql_soft_delete_field=deleted
-mysql_query_debug=false
+mysql_host=localhost
+mysql_user=database_user
+mysql_password=database_password
+mysql_database=database_name
 mysql_port=3306

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-mysql",
-  "version": "1.4.0",
+  "version": "1.4.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -200,7 +200,7 @@
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "dev": true,
       "requires": {
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        "lodash": "4.17.4"
       }
     },
     "async-each": {
@@ -1315,7 +1315,7 @@
         "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.24.1.tgz",
         "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.24.1.tgz",
         "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.17.0.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        "lodash": "4.17.4"
       }
     },
     "babel-traverse": {
@@ -1331,7 +1331,7 @@
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.4.tgz",
         "globals": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
         "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+        "lodash": "4.17.4"
       }
     },
     "babel-types": {
@@ -1341,7 +1341,7 @@
       "requires": {
         "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
         "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "lodash": "4.17.4",
         "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
       }
     },
@@ -1860,7 +1860,7 @@
         "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -2067,12 +2067,6 @@
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
       }
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -3041,6 +3035,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -3049,14 +3051,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3432,7 +3426,7 @@
         "cli-width": "2.2.0",
         "external-editor": "2.0.5",
         "figures": "2.0.0",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "lodash": "4.17.4",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rx-lite": "4.0.8",
@@ -3740,23 +3734,6 @@
       "requires": {
         "handlebars": "4.0.10"
       }
-    },
-    "jasmine": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.8.0.tgz",
-      "integrity": "sha1-awicChFXax8W3xG4AUbZHU6Lij4=",
-      "dev": true,
-      "requires": {
-        "exit": "0.1.2",
-        "glob": "7.1.2",
-        "jasmine-core": "2.8.0"
-      }
-    },
-    "jasmine-core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.8.0.tgz",
-      "integrity": "sha1-vMl5rh+f0FcB5F5S5l06XWPxok4=",
-      "dev": true
     },
     "jest": {
       "version": "21.2.1",
@@ -4077,32 +4054,6 @@
         "pretty-format": "21.2.1"
       }
     },
-    "js-mysql-migration": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/js-mysql-migration/-/js-mysql-migration-1.0.5.tgz",
-      "integrity": "sha512-gNUhPO67cgbVF8vMWo9Xzj/aYMGvo91VOkconyLGB7+t2xy5XwHO5nMMEMtBdTD6s8VHvNGrSkCgosHtdfetKg==",
-      "dev": true,
-      "requires": {
-        "dotenv": "4.0.0",
-        "jasmine": "2.8.0",
-        "js-mysql": "1.4.0",
-        "mysql2": "1.3.5"
-      },
-      "dependencies": {
-        "js-mysql": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/js-mysql/-/js-mysql-1.4.0.tgz",
-          "integrity": "sha512-vRWeoXDB3KZKna5Ta4BdDEp20QVVnieXxnzGwoOh/nleSW5CDh6D3cEMBkaHYphSAdc3MQxFJ/4aR7TQL/mxZw==",
-          "dev": true,
-          "requires": {
-            "dotenv": "4.0.0",
-            "jasmine": "2.8.0",
-            "moment": "2.18.1",
-            "mysql2": "1.3.5"
-          }
-        }
-      }
-    },
     "js-tokens": {
       "version": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
       "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
@@ -4288,9 +4239,9 @@
       }
     },
     "lodash": {
-      "version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -5385,6 +5336,13 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "string_decoder": {
+      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
+      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
+      "requires": {
+        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -5403,13 +5361,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-      }
-    },
-    "string_decoder": {
-      "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-      "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc=",
-      "requires": {
-        "buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
       }
     },
     "stringstream": {
@@ -5467,7 +5418,7 @@
         "ajv": "5.2.3",
         "ajv-keywords": "2.1.0",
         "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-        "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+        "lodash": "4.17.4",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "dotenv": "^4.0.0",
+    "lodash": "^4.17.4",
     "moment": "^2.18.1",
     "mysql2": "^1.3.5"
   },

--- a/src/mysql/config.js
+++ b/src/mysql/config.js
@@ -1,28 +1,32 @@
-const env = require('dotenv')
+const merge = require('lodash/merge')
 
-const templatePath =
-`${__dirname}/../template-files/.env_template`
+/**
+ * Load .env settings into process.env
+ * Will fail silently if no .env file present
+ */
+require('dotenv').config()
 
-const getTemplateConfig = () =>
-  env.config({ path: templatePath }).parsed
+/**
+ * Get default configs
+ */
+const config = require('./env/default')
 
-const getConfig = () =>
-  env.config().parsed
-
-const backupConfig = {
-  port: 8080,
-  allowCrossDomain: false,
-  https: false,
-  mysql_host: 'localhost',
-  mysql_user: 'root',
-  mysql_password: '',
-  mysql_database: '',
-  mysql_soft_delete: false,
-  mysql_soft_delete_field: 'deleted',
-  mysql_query_debug: false,
-  mysql_port: 3306
+/**
+ * Get local configs
+ */
+let localConfig
+try {
+  // Local configs may not exist
+  localConfig = require(`./env/${config.env}`)
+  localConfig = localConfig || {}
+} catch (err) {
+  localConfig = {}
 }
 
-const config = getConfig() || getTemplateConfig() || backupConfig
+/**
+ * Merge the config files
+ * localConfig will override defaults
+ */
+merge({}, config, localConfig)
 
 export default config

--- a/src/mysql/env/default.js
+++ b/src/mysql/env/default.js
@@ -1,0 +1,22 @@
+const config = {
+  port: process.env.PORT || 8080,
+  allowCrossDomain: false,
+  https: false,
+  mysql_host: process.env.mysql_host,
+  mysql_user: process.env.mysql_user,
+  mysql_password: process.env.mysql_password,
+  mysql_database: process.env.mysql_database,
+  mysql_soft_delete: false,
+  mysql_soft_delete_field: 'deleted',
+  mysql_query_debug: false,
+  mysql_port: 3306,
+  charset: 'utf8'
+}
+
+/**
+ * Set the current environment or default to 'development'
+ */
+process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+config.env = process.env.NODE_ENV
+
+export default config

--- a/src/mysql/env/development.js
+++ b/src/mysql/env/development.js
@@ -1,0 +1,5 @@
+const config = {
+  mysql_query_debug: true
+}
+
+export default config

--- a/src/mysql/index.js
+++ b/src/mysql/index.js
@@ -22,7 +22,7 @@ const whereObj = where => Object.keys(where).map(key => `${key} = ? `).join(' AN
 const whereValues = where => (!where || typeof (where) === 'string' ? [] : Object.keys(where).map(key => quoteIfStrOrDate(where[key])))
 
 const handleSoftDelete = where =>
-  (config.mysql_soft_delete === 'true' ?
+  (config.mysql_soft_delete ?
     where.toLowerCase().replace('where', '').trim().length > 0 ?
       `${where} AND ${config.mysql_soft_delete_field} = 0 ` :
       `${config.mysql_soft_delete_field} = 0 ` :
@@ -43,7 +43,7 @@ const sqlValuesPrepared = obj => Object.values(obj).map(_ => '?').join()
 const objectToCreateQuery = (table, obj) => sql.insert(table, sqlFields(obj), sqlValuesPrepared(obj))
 
 const printQuery = (query, vals) => {
-  if (config.mysql_query_debug == 'true') {
+  if (config.mysql_query_debug) {
     console.log([query, vals])
   }
   return query
@@ -107,7 +107,7 @@ export function update(table, updates, where) {
 }
 
 export function _delete(table, where) {
-  if (config.mysql_soft_delete !== 'true') {
+  if (!config.mysql_soft_delete) {
     return getConnection()
       .then(runQuery(sql._delete(table, prepareWhere(where)), whereValues(where)))
   }


### PR DESCRIPTION
This PR is the result of trying to address 2 primary issues:
1. Non-sensitive configs, such as `mysql_query_debug`, do not need to be in the `.env` file.
2. It would be logical to evaluate `config.mysql_query_debug` and `config.mysql_soft_delete` as booleans rather than strings.

Bonus:
Local settings for overriding default configs.